### PR TITLE
Make install.sh more idempotent

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,11 +9,11 @@ ln -sf $DOTFILES_DIRECTORY/zsh/zprofile $HOME/.zprofile
 cp $DOTFILES_DIRECTORY/zsh/zshenv.example $DOTFILES_DIRECTORY/zsh/zshenv
 ln -sf $DOTFILES_DIRECTORY/zsh/zshenv $HOME/.zshenv
 
-ln -sf $DOTFILES_DIRECTORY/vim $HOME/.vim
+ln -hsF $DOTFILES_DIRECTORY/vim $HOME/.vim
 ln -sf $DOTFILES_DIRECTORY/vim/vimrc $HOME/.vimrc
 
-ln -sf $DOTFILES_DIRECTORY/yabai $HOME/.config/yabai
-ln -sf $DOTFILES_DIRECTORY/skhd $HOME/.config/skhd
+ln -hsF $DOTFILES_DIRECTORY/yabai $HOME/.config/yabai
+ln -hsF $DOTFILES_DIRECTORY/skhd $HOME/.config/skhd
 
 # Set up Vim directories:
 mkdir ~/.vim/backups


### PR DESCRIPTION
from `LN(1)`:

```
     -h    If the target_file or target_dir is a symbolic link, do not follow it.
           This is most useful with the -f option, to replace a symlink which may point to a
           directory.
```

This prevents a symlink from being created _within_ `~/.config/yabai` (i.e. at `~/.config/yabai/yabai`) when `~/.config/yabai` already exists. (i.e. if you run `install.sh` again)


also, changing `-f` to `-F` is to specifically affect directories instead of also affecting files

```
     -F    If the target file already exists and is a directory, then remove it so that the link may occur. 
           The -F option should be used with either -f or -i options.
           If neither -f nor -i is specified, -f is implied.  The -F option is a no-op unless -s is specified.

     -f    If the target file already exists, then unlink it so that the link may occur. 
           (The -f option overrides any previous -i and -w options.)
```