### PR TITLE
yabai: delete missing settings

### DIFF
--- a/yabai/yabairc
+++ b/yabai/yabairc
@@ -2,13 +2,11 @@
 
 # Global settings
 yabai -m config window_placement             second_child
-yabai -m config window_topmost               on
 
 yabai -m config split_ratio                  0.50
 yabai -m config auto_balance                 off
 
 yabai -m config window_shadow                on
-yabai -m config window_border                off
 yabai -m config window_opacity               off
 
 yabai -m config mouse_modifier               fn


### PR DESCRIPTION
Fix warnings when running `yabai` in the foreground:

```
$ yabai
unknown command 'window_topmost' for domain 'config'
unknown command 'on' for domain 'config'
unknown command 'window_border' for domain 'config'
unknown command 'off' for domain 'config'
yabai configuration loaded..
```

- `window_topmost` deleted in https://github.com/koekeishiya/yabai/commit/8c04df460973eeaf9eb79fa5522875752bc36c94
- `window_border` deleted in https://github.com/koekeishiya/yabai/commit/5dd912f617ae8d5e2f2a27a84201ae6b4b5dc7b7